### PR TITLE
Add experimental support for stack-based builds, update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ src/ui/android/obj/
 .cabal-sandbox
 cabal.sandbox.config
 DATA_DIR
+.stack-work/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ GF particularly addresses four aspects of grammars:
 
 ## Compilation and installation
 
+### Dependencies
+
+You need the C library `fcgi`[^1].  You also need to build the C
+libraries in `src/runtime/c/`.
+
+[^1]: On ubuntu available in the package: `libfcgi-dev`
+
+### Building
+
 The simplest way of installing GF is with the command:
 ```
 cabal install

--- a/stack-lts-12.4.yaml
+++ b/stack-lts-12.4.yaml
@@ -1,0 +1,27 @@
+resolver: lts-12.4
+
+packages:
+- ./
+- src/pgf-binary/
+- src/runtime/haskell-bind/
+- src/runtime/haskell/
+- src/tools/
+# Failed building:
+# - src/server/
+# - src/example-based/
+
+extra-deps:
+# Non-standard clone of `cgi` needed because of too strict version
+# bounds in upstream version.  Those version bounds do not play nice
+# with lts-12.4.
+- git: git@github.com:MUSTE-Project/haskell-cgi.git
+  commit: b45aabe6ccfd5aa81c5883b25fef019d60e9d9d0
+- fastcgi-3001.0.2.4
+- fst-0.10.0.1
+- network-2.6.3.6
+
+# This is where the c-libaries from `src/runtime/c/` end up.
+extra-include-dirs:
+- /usr/local/include/
+extra-lib-dirs:
+- /usr/local/lib/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+stack-lts-12.4.yaml


### PR DESCRIPTION
I just successfully installed this package on

    > uname -rov
    4.15.0-29-generic #31-Ubuntu SMP Tue Jul 17 15:39:52 UTC 2018 GNU/Linux

I added the steps I needed to take for a successful build to the
README.

You may not want to formally support stack-based builds, but I find
that at least including a stack.yaml file serves as great
documentation for a package set that is known to at least successfully
build.