### PR TITLE
Expose the internals of `CId`

### DIFF
--- a/src/runtime/haskell/PGF.hs
+++ b/src/runtime/haskell/PGF.hs
@@ -20,7 +20,7 @@ module PGF(
            parsePGF,
 
            -- * Identifiers
-           CId, mkCId, wildCId,
+           CId, mkCId, wildCId, unCId,
            showCId, readCId,
            -- extra
            ppCId, pIdent, utf8CId,

--- a/src/runtime/haskell/PGF/CId.hs
+++ b/src/runtime/haskell/PGF/CId.hs
@@ -15,7 +15,7 @@ import qualified Text.PrettyPrint as PP
 
 -- | An abstract data type that represents
 -- identifiers for functions and categories in PGF.
-newtype CId = CId BS.ByteString deriving (Eq,Ord)
+newtype CId = CId { unCId :: BS.ByteString } deriving (Eq,Ord)
 
 wildCId :: CId
 wildCId = CId (BS.singleton '_')


### PR DESCRIPTION
I'd like to be able to efficiently convert `CId`s to `Text`. I need access to the internals to do this.