### PR TITLE
Fix deprecations from containers >= 0.4.0.0

### DIFF
--- a/src/runtime/haskell/PGF.hs
+++ b/src/runtime/haskell/PGF.hs
@@ -374,7 +374,7 @@ browse pgf id = fmap (\def -> (def,producers,consumers)) definition
                                   Just (hyps,_,_) -> Just $ render (text "cat" <+> ppCId id <+> hsep (snd (mapAccumL (ppHypo 4) [] hyps)))
                                   Nothing         -> Nothing
 
-    (producers,consumers) = Map.foldWithKey accum ([],[]) (funs (abstract pgf))
+    (producers,consumers) = Map.foldrWithKey accum ([],[]) (funs (abstract pgf))
       where
         accum f (ty,_,_,_) (plist,clist) = 
           let !plist' = if id `elem` ps then f : plist else plist

--- a/src/runtime/haskell/PGF/Optimize.hs
+++ b/src/runtime/haskell/PGF/Optimize.hs
@@ -185,8 +185,8 @@ filterProductions prods0 prods
   | prods0 == prods1 = prods0
   | otherwise        = filterProductions prods1 prods
   where
-    prods1 = IntMap.foldWithKey foldProdSet IntMap.empty prods
-    hoc    = IntMap.fold (\set !hoc -> Set.fold accumHOC hoc set) IntSet.empty prods
+    prods1 = IntMap.foldrWithKey foldProdSet IntMap.empty prods
+    hoc    = IntMap.foldr (\set !hoc -> Set.fold accumHOC hoc set) IntSet.empty prods
 
     foldProdSet fid set !prods
       | Set.null set1 = prods
@@ -204,7 +204,7 @@ filterProductions prods0 prods
     accumHOC _                   hoc = hoc
 
 splitLexicalRules cnc p_prods =
-  IntMap.foldWithKey split (IntMap.empty,IntMap.empty) p_prods
+  IntMap.foldrWithKey split (IntMap.empty,IntMap.empty) p_prods
   where
     split fid set (lex,syn) =
       let (lex0,syn0) = Set.partition isLexical set

--- a/src/runtime/haskell/PGF/TrieMap.hs
+++ b/src/runtime/haskell/PGF/TrieMap.hs
@@ -79,12 +79,12 @@ unionsWith f = foldl (unionWith f) empty
 elems :: TrieMap k v -> [v]
 elems tr = collect tr []
   where
-    collect (Tr mb_v m) xs = maybe id (:) mb_v (Map.fold collect xs m)
+    collect (Tr mb_v m) xs = maybe id (:) mb_v (Map.foldr collect xs m)
 
 toList :: TrieMap k v -> [([k],v)]
 toList tr = collect [] tr []
   where
-    collect ks (Tr mb_v m) xs = maybe id (\v -> (:) (ks,v)) mb_v (Map.foldWithKey (\k -> collect (k:ks)) xs m)
+    collect ks (Tr mb_v m) xs = maybe id (\v -> (:) (ks,v)) mb_v (Map.foldrWithKey (\k -> collect (k:ks)) xs m)
 
 fromListWith :: Ord k => (v -> v -> v) -> [([k],v)] -> TrieMap k v
 fromListWith f xs = foldl' (\trie (ks,v) -> insertWith f ks v trie) empty xs


### PR DESCRIPTION
E.g. `foldrWithKey` has been deprecated since [0.4.0.0](https://github.com/haskell/containers/blob/master/changelog.md#0400--nov-2010) (November 2010) and has
been removed in [0.6.0.1](https://github.com/haskell/containers/blob/master/changelog.md#death-of-deprecated-functions) (2018)
