### PR TITLE
Fix deprecations from containers >= 0.4.0.0

### DIFF
--- a/src/compiler/GF/Speech/PGFToCFG.hs
+++ b/src/compiler/GF/Speech/PGFToCFG.hs
@@ -57,7 +57,7 @@ pgfToCFG pgf lang = mkCFG (showCId (lookStartCat pgf)) extCats (startRules ++ co
 
     topdownRules cat = f cat []
       where
-        f cat rules = maybe rules (Set.fold g rules) (IntMap.lookup cat (productions cnc))
+        f cat rules = maybe rules (Set.foldr g rules) (IntMap.lookup cat (productions cnc))
 	 
         g (PApply funid args) rules = (cncfuns cnc ! funid,args) : rules
         g (PCoerce cat)       rules = f cat rules

--- a/src/runtime/haskell/PGF.hs
+++ b/src/runtime/haskell/PGF.hs
@@ -374,7 +374,7 @@ browse pgf id = fmap (\def -> (def,producers,consumers)) definition
                                   Just (hyps,_,_) -> Just $ render (text "cat" <+> ppCId id <+> hsep (snd (mapAccumL (ppHypo 4) [] hyps)))
                                   Nothing         -> Nothing
 
-    (producers,consumers) = Map.foldWithKey accum ([],[]) (funs (abstract pgf))
+    (producers,consumers) = Map.foldrWithKey accum ([],[]) (funs (abstract pgf))
       where
         accum f (ty,_,_,_) (plist,clist) = 
           let !plist' = if id `elem` ps then f : plist else plist

--- a/src/runtime/haskell/PGF/Forest.hs
+++ b/src/runtime/haskell/PGF/Forest.hs
@@ -190,7 +190,7 @@ foldForest :: (FunId -> [PArg] -> b -> b) -> (Expr -> [String] -> b -> b) -> b -
 foldForest f g b fcat forest =
   case IntMap.lookup fcat forest of
     Nothing  -> b
-    Just set -> Set.fold foldProd b set
+    Just set -> Set.foldr foldProd b set
   where
     foldProd (PCoerce fcat)        b = foldForest f g b fcat forest
     foldProd (PApply funid args)   b = f funid args b

--- a/src/runtime/haskell/PGF/Optimize.hs
+++ b/src/runtime/haskell/PGF/Optimize.hs
@@ -185,8 +185,8 @@ filterProductions prods0 prods
   | prods0 == prods1 = prods0
   | otherwise        = filterProductions prods1 prods
   where
-    prods1 = IntMap.foldWithKey foldProdSet IntMap.empty prods
-    hoc    = IntMap.fold (\set !hoc -> Set.fold accumHOC hoc set) IntSet.empty prods
+    prods1 = IntMap.foldrWithKey foldProdSet IntMap.empty prods
+    hoc    = IntMap.foldr (\set !hoc -> Set.foldr accumHOC hoc set) IntSet.empty prods
 
     foldProdSet fid set !prods
       | Set.null set1 = prods
@@ -204,7 +204,7 @@ filterProductions prods0 prods
     accumHOC _                   hoc = hoc
 
 splitLexicalRules cnc p_prods =
-  IntMap.foldWithKey split (IntMap.empty,IntMap.empty) p_prods
+  IntMap.foldrWithKey split (IntMap.empty,IntMap.empty) p_prods
   where
     split fid set (lex,syn) =
       let (lex0,syn0) = Set.partition isLexical set

--- a/src/runtime/haskell/PGF/Parse.hs
+++ b/src/runtime/haskell/PGF/Parse.hs
@@ -198,7 +198,7 @@ recoveryStates open_types (EState abs cnc chart) =
                                   Nothing                  -> []
 
     complete open_fcats items ac = 
-      foldl (Set.fold (\(Active j' ppos funid seqid args keyc) -> 
+      foldl (Set.foldr (\(Active j' ppos funid seqid args keyc) -> 
                            (:) (Active j' (ppos+1) funid seqid args keyc)))
             items
             [set | fcat <- open_fcats, (set,_) <- lookupACByFCat fcat ac]
@@ -363,7 +363,7 @@ process flit ftok cnc (item@(Active j ppos funid seqid args key0):items) acc cha
                        
                        items2 = case lookupAC key0 ((active chart:actives chart) !! (k-j)) of
                                   Nothing       -> items
-                                  Just (set,sc) -> Set.fold (\(Active j' ppos funid seqid args keyc) -> 
+                                  Just (set,sc) -> Set.foldr (\(Active j' ppos funid seqid args keyc) -> 
                                                                 let SymCat d _ = unsafeAt (unsafeAt (sequences cnc) seqid) ppos
                                                                     PArg hypos _ = args !! d
                                                                 in (:) (Active j' (ppos+1) funid seqid (updateAt d (PArg hypos fid) args) keyc)) items set
@@ -395,7 +395,7 @@ process flit ftok cnc (item@(Active j ppos funid seqid args key0):items) acc cha
     predict flit ftok cnc forest key0 key@(AK fid lbl) k acc items =
       let (acc1,items1) = case IntMap.lookup fid forest of
                             Nothing  -> (acc,items)
-                            Just set -> Set.fold foldProd (acc,items) set
+                            Just set -> Set.foldr foldProd (acc,items) set
 
           (acc2,items2) = case IntMap.lookup fid (lexicon cnc) >>= IntMap.lookup lbl of
                             Just tmap -> let (mb_v,toks) = TrieMap.decompose (TrieMap.map (toItems key0 k) tmap)

--- a/src/runtime/haskell/PGF/TrieMap.hs
+++ b/src/runtime/haskell/PGF/TrieMap.hs
@@ -79,12 +79,12 @@ unionsWith f = foldl (unionWith f) empty
 elems :: TrieMap k v -> [v]
 elems tr = collect tr []
   where
-    collect (Tr mb_v m) xs = maybe id (:) mb_v (Map.fold collect xs m)
+    collect (Tr mb_v m) xs = maybe id (:) mb_v (Map.foldr collect xs m)
 
 toList :: TrieMap k v -> [([k],v)]
 toList tr = collect [] tr []
   where
-    collect ks (Tr mb_v m) xs = maybe id (\v -> (:) (ks,v)) mb_v (Map.foldWithKey (\k -> collect (k:ks)) xs m)
+    collect ks (Tr mb_v m) xs = maybe id (\v -> (:) (ks,v)) mb_v (Map.foldrWithKey (\k -> collect (k:ks)) xs m)
 
 fromListWith :: Ord k => (v -> v -> v) -> [([k],v)] -> TrieMap k v
 fromListWith f xs = foldl' (\trie (ks,v) -> insertWith f ks v trie) empty xs


### PR DESCRIPTION
E.g. `foldWithKey` has been deprecated since 0.4.0.0 (November 2010)[1] and has been removed in 0.6.0.1 (2018)[2]

[1]: https://github.com/haskell/containers/blob/master/changelog.md#0400--nov-2010
[2]: https://github.com/haskell/containers/blob/master/changelog.md#death-of-deprecated-functions

(commit originally by @fredefox)