### PR TITLE
(gf2ud) allow multiple labels files

### DIFF
--- a/src/compiler/GF/Command/Abstract.hs
+++ b/src/compiler/GF/Command/Abstract.hs
@@ -44,10 +44,14 @@ valIntOpts flag def opts =
     _     -> def
 
 valStrOpts :: String -> String -> [Option] -> String
-valStrOpts flag def opts =
+valStrOpts flag def opts = head $ valStrsOpts flag def opts
+
+
+valStrsOpts :: String -> String -> [Option] -> [String]
+valStrsOpts flag def opts =
   case listFlags flag opts of
-    v:_ -> valueString v
-    _   -> def
+    [] -> [def]
+    vs -> fmap valueString vs
 
 listFlags flag opts = [v | OFlag f v <- opts, f == flag]
 

--- a/src/compiler/GF/Command/Commands.hs
+++ b/src/compiler/GF/Command/Commands.hs
@@ -550,15 +550,15 @@ pgfCommands = Map.fromList [
          let absname = abstractName pgf
          let es = toExprs arg
          let debug = isOpt "v" opts
-         let abslabels = valStrOpts "abslabels" (valStrOpts "file" "" opts) opts
-         let cnclabels = valStrOpts "cnclabels" "" opts
+         let abslabels = valStrsOpts "abslabels" (valStrOpts "file" [] opts) opts
+         let cnclabels = valStrsOpts "cnclabels" [] opts
          let outp = valStrOpts "output" "dot" opts
          mlab <- case abslabels of
-           "" -> return Nothing
-           _  -> (Just . getDepLabels) `fmap` restricted (readFile abslabels)
+           [] -> return Nothing
+           _  -> (Just . getDepLabels . concat) `fmap` restricted (sequence (fmap readFile abslabels))
          mclab <- case cnclabels of
-           "" -> return Nothing
-           _  -> (Just . getCncDepLabels) `fmap` restricted (readFile cnclabels)
+           [] -> return Nothing
+           _  -> (Just . getCncDepLabels . concat) `fmap` restricted (sequence (fmap readFile cnclabels))
          let lang = optLang pgf opts
          let grphs = map (graphvizDependencyTree outp debug mlab mclab pgf lang) es
          if isOpt "conll2latex" opts

--- a/src/compiler/GF/Infra/SIO.hs
+++ b/src/compiler/GF/Infra/SIO.hs
@@ -92,7 +92,7 @@ captureSIO sio   = do ch <- newChan
                      takeJust (Just xs:ys) = xs++takeJust ys
                      takeJust _ = []
 
--- * Restricted accesss to arbitrary (potentially unsafe) IO operations
+-- * Restricted access to arbitrary (potentially unsafe) IO operations
 
 restricted io    = SIO (const (restrictedIO io))
 restrictedSystem = restricted . system


### PR DESCRIPTION
sometimes one may wish to extend the existing RGL labels files using
one's own labels file. the naive way of doing this would be
copy-pasting the RGL labels file into a new file, and using that, but
then keeping it in sync would be bothersome.

the implementation in this commit is very simple: it makes the GF
shell accept (and use) several -abslabels and -cnclabels, and the file
contents are concatenated before being parsed.

warning1: I've tested only supplying an additional -abslabels file,
and it seemed to work. this is a quick hack, I can do more testing if
it is deemed necessary.

warning2: I'm still getting used to the gf-core
codebase, so if there is a better way of doing things, please let me
know.