### PR TITLE
(gf2ud) add comments to CoNLL-U output

### DIFF
--- a/src/runtime/haskell/PGF/VisualizeTree.hs
+++ b/src/runtime/haskell/PGF/VisualizeTree.hs
@@ -132,7 +132,7 @@ graphvizDependencyTree format debug mlab mclab pgf lang t =
   case format of
     "latex"      -> render . ppLaTeX $ conll2latex' conll
     "svg"        -> render . ppSVG . toSVG $ conll2latex' conll
-    "conll"      -> printCoNLL conll
+    "conll"      -> printCoNLL ([["# text = " ++ linearize pgf lang t], ["# tree = " ++ showExpr [] t]] ++ conll)
     "malt_tab"   -> render $ vcat (map (hcat . intersperse (char '\t') . (\ws -> [ws !! 0,ws !! 1,ws !! 3,ws !! 6,ws !! 7])) wnodes)
     "malt_input" -> render $ vcat (map (hcat . intersperse (char '\t') . take 6) wnodes)
     _            -> render $ text "digraph {" $$


### PR DESCRIPTION
when debbuging labels, I find it useful to have comments saying what's
the original sentence (lazy, I know) and the original tree (depending
on the treebank, the trees can be similar).

I know this is not the goal exactly, but UDv2 treebanks
(http://universaldependencies.org/format.html) should always have a
'text =' comment, and a 'sent_id =' comment (which would be easy to
implement too, but not that useful).

example output:
```conllu
# text = a janela abria
# tree = PhrUtt NoPConj (UttS (UseCl (TTAnt TPast ASimul) PPos (PredVP (DetCN (DetQuant DefArt NumSg) (UseN window_N)) (UseV open_V)))) NoVoc
1	a	DefArt	DET	Quant	Quant-6	2	det	_	_
2	janela	window_N	NOUN	N	N-0	3	nsubj	_	_
3	abria	open_V	VERB	V	V-15	0	root	_	_
```