### PR TITLE
Expose PGF/Concr/Iter/Bracket

### DIFF
--- a/src/runtime/python/pypgf.c
+++ b/src/runtime/python/pypgf.c
@@ -3497,9 +3497,16 @@ MOD_INIT(pgf)
     PyModule_AddObject(m, "Type", (PyObject *) &pgf_TypeType);
     Py_INCREF(&pgf_TypeType);
 
+    PyModule_AddObject(m, "PGF", (PyObject *) &pgf_PGFType);
     Py_INCREF(&pgf_PGFType);
+	
+    PyModule_AddObject(m, "Concr", (PyObject *) &pgf_ConcrType);
     Py_INCREF(&pgf_ConcrType);
+
+    PyModule_AddObject(m, "Iter", (PyObject *) &pgf_IterType);
     Py_INCREF(&pgf_IterType);
+
+    PyModule_AddObject(m, "Bracket", (PyObject *) &pgf_BracketType);
     Py_INCREF(&pgf_BracketType);
 
 	return MOD_SUCCESS_VAL(m);


### PR DESCRIPTION
Expose the remaining types in the module.

These are helpful for example in type annotations.