### PR TITLE
Build Debian package via GitHub action

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -31,10 +31,8 @@ jobs:
           pandoc
 
     - name: Checkout RGL
-      env:
-        working-directory: ../
       run: |
-        git clone https://github.com/GrammaticalFramework/gf-rgl.git
+        git clone --depth 1 https://github.com/GrammaticalFramework/gf-rgl.git ../gf-rgl
 
     - name: Build Debian package
       run: |

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -26,7 +26,9 @@ jobs:
           libghc-json-dev \
           python-dev \
           default-jdk \
-          libtool-bin
+          libtool-bin \
+          txt2tags \
+          pandoc
 
     - name: Checkout RGL
       env:

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -18,7 +18,8 @@ jobs:
 
     - name: Install build tools
       run: |
-        apt install -y make \
+        sudo apt install -y \
+          make \
           dpkg-dev \
           debhelper \
           haskell-platform \

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -39,5 +39,7 @@ jobs:
         make deb
 
     - uses: actions/upload-artifact@v2
+      env:
+        working-directory: ..
       with:
-        path: ../gf_*.deb
+        path: gf_*.deb

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -38,8 +38,11 @@ jobs:
       run: |
         make deb
 
+    - name: Copy packages
+      run: |
+        mkdir debian/dist
+        cp ../gf_*.deb debian/dist/
+
     - uses: actions/upload-artifact@v2
-      env:
-        working-directory: ..
       with:
-        path: gf_*.deb
+        path: debian/dist

--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -1,0 +1,42 @@
+name: Build Debian Package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-18.04]
+    env:
+      LC_ALL: C.UTF-8
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install build tools
+      run: |
+        apt install -y make \
+          dpkg-dev \
+          debhelper \
+          haskell-platform \
+          libghc-json-dev \
+          python-dev \
+          default-jdk \
+          libtool-bin
+
+    - name: Checkout RGL
+      env:
+        working-directory: ../
+      run: |
+        git clone https://github.com/GrammaticalFramework/gf-rgl.git
+
+    - name: Build Debian package
+      run: |
+        make deb
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ../gf_*.deb


### PR DESCRIPTION
This PR adds a GitHub action for building a GF Debian package, as described in #63. The resulting `.deb` package becomes an "artifact" of the action run, which is only available if you are logged in to GitHub and doesn't have a predictable URL. So not usable from a Dockerfile or similar, which is one of the main motivations of this. We need to figure out a suitable place (and naming convention) for publishing these packages.