### PR TITLE
New features in PGF to Haskell translation

### DIFF
--- a/src/compiler/GF/Compile/PGFtoHaskell.hs
+++ b/src/compiler/GF/Compile/PGFtoHaskell.hs
@@ -119,7 +119,7 @@ hDatatype gId derivingClause lexical (cat,rules) =
  "data" +++ gId cat +++ "=" ++
  (if length rules == 1 then "" else "\n  ") +++
  foldr1 (\x y -> x ++ "\n |" +++ y) constructors ++++
- "  " +++ derivingClause
+ " " +++ derivingClause
   where
     constructors = [gId f +++ foldr (+++) "" (map (gId) xx) | (f,xx) <- nonLexicalRules (lexical cat) rules]
                    ++ if lexical cat then [lexicalConstructor cat +++ "String"] else []

--- a/src/compiler/GF/Compile/PGFtoHaskell.hs
+++ b/src/compiler/GF/Compile/PGFtoHaskell.hs
@@ -44,7 +44,7 @@ grammar2haskell opts name gr = foldr (++++) [] $
               | otherwise = ("G"++) . rmForbiddenChars
           -- GF grammars allow weird identifier names inside '', e.g. 'VP/Object'
           rmForbiddenChars = filter (`notElem` "'!#$%&*+./<=>?@\\^|-~")
-          pragmas | gadt = ["{-# OPTIONS_GHC -fglasgow-exts #-}","{-# LANGUAGE GADTs #-}"]
+          pragmas | gadt = ["{-# LANGUAGE GADTs, FlexibleInstances, KindSignatures, RankNTypes, TypeSynonymInstances #-}"]
                   | dataExt = ["{-# LANGUAGE DeriveDataTypeable #-}"]
                   | otherwise = []
           derivingClause

--- a/src/compiler/GF/Compile/PGFtoHaskell.hs
+++ b/src/compiler/GF/Compile/PGFtoHaskell.hs
@@ -40,8 +40,10 @@ grammar2haskell opts name gr = foldr (++++) [] $
           gadt = haskellOption opts HaskellGADT
           dataExt = haskellOption opts HaskellData
           lexical cat = haskellOption opts HaskellLexical && isLexicalCat opts cat
-          gId | haskellOption opts HaskellNoPrefix = id
-              | otherwise = ("G"++)
+          gId | haskellOption opts HaskellNoPrefix = rmForbiddenChars
+              | otherwise = ("G"++) . rmForbiddenChars
+          -- GF grammars allow weird identifier names inside '', e.g. 'VP/Object'
+          rmForbiddenChars = filter (`notElem` "'!#$%&*+./<=>?@\\^|-~")
           pragmas | gadt = ["{-# OPTIONS_GHC -fglasgow-exts #-}","{-# LANGUAGE GADTs #-}"]
                   | dataExt = ["{-# LANGUAGE DeriveDataTypeable #-}"]
                   | otherwise = []

--- a/src/compiler/GF/Infra/Option.hs
+++ b/src/compiler/GF/Infra/Option.hs
@@ -131,7 +131,7 @@ data CFGTransform = CFGNoLR
   deriving (Show,Eq,Ord)
 
 data HaskellOption = HaskellNoPrefix | HaskellGADT | HaskellLexical
-                   | HaskellConcrete | HaskellVariants
+                   | HaskellConcrete | HaskellVariants | HaskellData
   deriving (Show,Eq,Ord)
 
 data Warning = WarnMissingLincat
@@ -530,7 +530,8 @@ haskellOptionNames =
      ("gadt",     HaskellGADT),
      ("lexical",  HaskellLexical),
      ("concrete", HaskellConcrete),
-     ("variants", HaskellVariants)]
+     ("variants", HaskellVariants),
+     ("data",     HaskellData)]
 
 -- | This is for bacward compatibility. Since GHC 6.12 we
 -- started using the native Unicode support in GHC but it


### PR DESCRIPTION
1. (030c3bf) Add new command line argument `--haskell=data` to add `{-# LANGUAGE DeriveDataTypeable #-}`, import [`Data.Data`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-Data.html) and make every data type derive `Data`.

2. (aeabc95) GF allows category names to have characters that are not allowed in Haskell data types. This commit removes those characters from the translated Haskell data types.

Tested with my own grammar that prompted me to make these changes. Let me know what more I should test this with.