### PR TITLE
Fix syntax error problem for older versions of GHC

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install cibuildwheel
       run: |
-        python -m pip install cibuildwheel==1.4.2  
+        python -m pip install git+https://github.com/joerick/cibuildwheel.git@master
 
     - name: Install build tools for OSX
       if: startsWith(matrix.os, 'macos')
@@ -69,7 +69,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    
+
     steps:
       - uses: actions/checkout@v2
 

--- a/src/compiler/GF/Grammar/Lexer.x
+++ b/src/compiler/GF/Grammar/Lexer.x
@@ -35,7 +35,7 @@ $u = [.\n]                -- universal: any character
 
 :-
 "--" [.]* ; -- Toss single line comments
-"{-" ([$u # \-] | \- [$u # \}])* ("-")+ "}" ; 
+"{-" ([$u # \-] | \- [$u # \}])* ("-")+ "}" ;
 
 $white+ ;
 @rsyms                          { tok ident }
@@ -138,7 +138,7 @@ data Token
 
 res = eitherResIdent
 eitherResIdent :: (Ident -> Token) -> Ident -> Token
-eitherResIdent tv s = 
+eitherResIdent tv s =
   case Map.lookup s resWords of
     Just t  -> t
     Nothing -> tv s
@@ -285,6 +285,10 @@ instance Monad P where
                              POk s a          -> unP (k a) s
                              PFailed posn err -> PFailed posn err
 
+#if !(MIN_VERSION_base(4,13,0))
+  -- Monad(fail) will be removed in GHC 8.8+
+  fail = Fail.fail
+#endif
 
 instance Fail.MonadFail P where
   fail msg    = P $ \(_,AI posn _ _) -> PFailed posn msg


### PR DESCRIPTION
This problem was introduced in #71

As reported by @inariksit:
> Symptom 1: Command line parameters not recognised, e.g.
> 
```
$ gf
> i -retain prelude/Prelude.gfo
> cc -all ss "hello"
syntax error
```
> 
> It should work like this:
> 
```
> i -retain prelude/Prelude.gfo
> cc -all ss "hello"
hello
```

> Symptom 2: error messages don't include line numbers. Example:


```
$ gf Foo.gf <some grammar with syntax errors>
- compiling Foo.gf... gf: syntax error
```

> Expected:

```
$ gf Foo.gf <some grammar with syntax errors>
- compiling Foogf... 

Foo.gf:381:21:
   syntax error
```


----

Here is a script that I used for testing for symptom 1:
```
stackFile=stack.yaml

stack build --stack-yaml $stackFile  --ghc-options -j || exit 125

echo -e 'i -retain prelude/Prelude.gfo\ncc -all ss "hello"' |  GF_LIB_PATH=../gf-rgl/result/rgl/ stack --stack-yaml $stackFile $nixFlag run gf
echo -e 'i -retain prelude/Prelude.gfo\ncc -all ss "hello"' |  GF_LIB_PATH=../gf-rgl/result/rgl/ stack --stack-yaml $stackFile $nixFlag run gf | grep "hello" || exit 1
```