### PR TITLE
WIP: Enable tests

### DIFF
--- a/gf.cabal
+++ b/gf.cabal
@@ -352,4 +352,5 @@ test-suite gf-tests
   main-is:        run.hs
   hs-source-dirs: testsuite
   build-depends:  base>=4.3 && <5, Cabal>=1.8, directory, filepath, process
+  build-tool-depends: gf:gf
   default-language:    Haskell2010

--- a/testsuite/run.hs
+++ b/testsuite/run.hs
@@ -14,7 +14,7 @@ main =
           ok = length good
           fail = ok<cnt
       putStrLn $ show ok++"/"++show cnt++ " passed/tests"
-      let overview = "dist/test/gf-tests.html"
+      let overview = "gf-tests.html"
       writeFile overview (toHTML bad)
       if ok<cnt 
         then do putStrLn $ overview++" contains an overview of the failed tests"
@@ -55,7 +55,8 @@ main =
 
     runTest in_file out_file gold_file = do
       input <- readFile in_file
-      writeFile out_file =<< run_gf input
+      rgl_lib_dir <- readFile "DATA_DIR"
+      writeFile out_file =<< run_gf ["-run","-gf-lib-path=" ++ rgl_lib_dir] input
       exists <- doesFileExist gold_file
       if exists
         then do out <- compatReadFile out_file
@@ -71,9 +72,8 @@ main =
          hGetContents h
 
 -- Should consult the Cabal configuration!
-run_gf = readProcess default_gf ["-run","-gf-lib-path="++gf_lib_path]
-default_gf = "dist/build/gf/gf"<.>exeExtension buildPlatform
-gf_lib_path = "dist/build/rgl"
+run_gf = readProcess default_gf 
+default_gf = "gf"<.>exeExtension buildPlatform
 
 -- | List files, excluding "." and ".."
 ls path = filter (`notElem` [".",".."]) `fmap` getDirectoryContents path


### PR DESCRIPTION
Here are fixes by @kharus to get the test suite working again (issue #8). The problem with the old hardcoded paths is fixed, and the RGL path is read using `DATA_DIR`, which seems to be the current standard.

I tested on my computer and the path problem looks solved. However, I got stuck at this stage for 10 minutes, and my computer started freezing, so I stopped the process.

```
Building test suite 'gf-tests' for gf-3.10.4..
[1 of 1] Compiling Main
Linking .stack-work/dist/x86_64-osx/Cabal-2.4.0.1/build/gf-tests/gf-tests ...
7 modules in 1 directories.
Progress 0/2
```

* Is the problem due to compiling the RGL? 
* Should we use the flag `--no-pmcfg`, like the setup script for the RGL does? Or would some important functionality be untested if we use that flag?
* Should we test the whole RGL with `--no-pmcfg`, and a subset of non-bloated RGL languages without the flag?
