### PR TITLE
Fix #92 (inappropriate error message)

### DIFF
--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1.1
+    - uses: actions/setup-haskell@v1.1.4
       id: setup-haskell-cabal
       name: Setup Haskell
       with:

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v2
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/master'
 
-    - uses: actions/setup-haskell@v1.1
+    - uses: actions/setup-haskell@v1.1.4
       name: Setup Haskell Stack
       with:
         # ghc-version: ${{ matrix.ghc }}

--- a/src/compiler/GF/Compile/GeneratePMCFG.hs
+++ b/src/compiler/GF/Compile/GeneratePMCFG.hs
@@ -622,7 +622,9 @@ ppbug msg = error completeMsg
  where
   originalMsg = render $ hang "Internal error in GeneratePMCFG:" 4 msg
   completeMsg =
-    unlines [originalMsg
+    case render msg of -- the error message for pattern matching a runtime string
+      "descend (CStr 0,CNil,CProj (LIdent (Id {rawId2utf8 = \"s\"})) CNil)"
+        -> unlines [originalMsg -- add more helpful output
             ,""
             ,"1) Check that you are not trying to pattern match a /runtime string/."
             ,"   These are illegal:"
@@ -633,5 +635,6 @@ ppbug msg = error completeMsg
             ,"2) Not about pattern matching? Submit a bug report and we update the error message."
             ,"     https://github.com/GrammaticalFramework/gf-core/issues"
             ]
+      _ -> originalMsg -- any other message: just print it as is
 
 ppU = ppTerm Unqualified


### PR DESCRIPTION
Fixes #92 

Used to print out a suggestion "maybe you're pattern matching at runtime" always when there was an internal error in GeneratePMCFG. 
Now checks what the actual error message is, and only prints out the suggestion for one specific error message.

Tested with the following grammars:
- https://gist.github.com/inariksit/88281c9698fd45a5f2bd00aaf14fa183 Example from #55 when the inappropriate message was introduced
- The minimal example from #49 (a previous issue that led to PR #55)
- The minimal example from #92 (issue that noticed the current bug).
