### PR TITLE
Add `-lines` option to `system_pipe`.

### DIFF
--- a/src/compiler/GF/Command/CommonCommands.hs
+++ b/src/compiler/GF/Command/CommonCommands.hs
@@ -170,9 +170,14 @@ commonCommands = fmap (mapCommandExec liftSIO) $ Map.fromList [
        restrictedSystem $ syst ++ " <" ++ tmpi ++ " >" ++ tmpo
        fmap fromString $ restricted $ readFile tmpo,
        -}
-       fmap fromString . restricted . readShellProcess syst $ toString arg,
+       case opts of
+         _ | isOpt "lines" opts ->  fmap (fromStrings . lines) . restricted . readShellProcess syst . unlines $ toStrings arg
+         _ -> fmap fromString . restricted . readShellProcess syst $ toString arg,
      flags = [
        ("command","the system command applied to the argument")
+       ],
+     options = [
+       ("lines","preserve input lines, and return output as a list of lines")
        ],
      examples = [
        mkEx "gt | l | ? wc  -- generate trees, linearize, and count words"


### PR DESCRIPTION
Without that, the example in `gf-shell-reference.html`
```
   gt | l | ? wc
```
always returns a zero (!) line count:
````
G1> gt | l | ? wc
      0    1157   10861

63 msec
G1> gt | l | sp -command="wc"
      0    1157   10861

70 msec
G1> gt | l | sp -lines -command="wc"
    294    1157   10862
````