### PR TITLE
Don't add automatic cost centres to Data.Binary.Get

### DIFF
--- a/src/runtime/haskell/Data/Binary/Get.hs
+++ b/src/runtime/haskell/Data/Binary/Get.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP, MagicHash #-}
+-- This module makes profiling a lot slower
+{-# OPTIONS_GHC -fno-prof-auto #-}
 -- for unboxed shifts
 
 -----------------------------------------------------------------------------

--- a/src/runtime/haskell/Data/Binary/Get.hs
+++ b/src/runtime/haskell/Data/Binary/Get.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP, MagicHash #-}
--- This module makes profiling a lot slower
+-- This module makes profiling a lot slower, so don't add automatic cost centres 
 {-# OPTIONS_GHC -fno-prof-auto #-}
 -- for unboxed shifts
 


### PR DESCRIPTION
When profiling the GF compiler using `ghc`s profiler, the majority of time is assigned to `Data.Binary.Get.>>=.\`, which doesn't make much sense. I belive inserting cost centres into that function is preventing some optimization from happening.

This patch disables automatic cost centres in that specific module, which significantly improves the runtime for the profiled version of the program.

When you're not running gf with `stack run --profile` or corresponding flags, this patch does nothing.