### PR TITLE
Always use UTF8 encoding in the gf executable

### DIFF
--- a/src/compiler/GF/Main.hs
+++ b/src/compiler/GF/Main.hs
@@ -16,6 +16,7 @@ import Data.Version
 import System.Directory
 import System.Environment (getArgs)
 import System.Exit
+import GHC.IO.Encoding
 -- import GF.System.Console (setConsoleEncoding)
 
 -- | Run the GF main program, taking arguments from the command line.
@@ -23,6 +24,7 @@ import System.Exit
 -- Run @gf --help@ for usage info.
 main :: IO ()
 main = do
+  setLocaleEncoding utf8
   -- setConsoleEncoding
   uncurry mainOpts =<< getOptions
 


### PR DESCRIPTION
This fixes many of the "Invalid character" messages
you can get on different platforms.

This has helped both with a nix-installation that didn't have global
locale set and with a windows installation.

I do not know if there are any situations where this would cause problems, but I have not encountered any so far. Everyone should be using UTF8 by now and GF files should always be UTF8 encoded regardless of your computer's default encoding.