### PR TITLE
Improve error messages for str pattern matching

### DIFF
--- a/src/compiler/GF/Compile/Compute/Concrete.hs
+++ b/src/compiler/GF/Compile/Compute/Concrete.hs
@@ -540,7 +540,7 @@ value2term' stop loc xs v0 =
     var :: HasCallStack => Int -> Term
     var j
       | j<length xs = Vr (reverse xs !! j)
-      | otherwise   = bugloc loc ("variable #"++show j++" is out of scope")
+      | otherwise   = Error ("variable #"++show j++" is out of scope in expression " ++ show v0 ++ " with context " ++show (reverse xs))
 
 
     pushs xs e = foldr push e xs


### PR DESCRIPTION
This also fixes some regressions in the error message from #87

This code can trigger the error: https://discord.com/channels/865093807343140874/865094084683366400/981235590097956905