### PR TITLE
Improve performance with long extend-lists

### DIFF
--- a/src/compiler/GF/Grammar/Grammar.hs
+++ b/src/compiler/GF/Grammar/Grammar.hs
@@ -78,6 +78,7 @@ import PGF.Internal (FId, FunId, SeqId, LIndex, Sequence, BindType(..))
 import Data.Array.IArray(Array)
 import Data.Array.Unboxed(UArray)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import GF.Text.Pretty
 
 
@@ -125,10 +126,12 @@ extends :: ModuleInfo -> [ModuleName]
 extends = map fst . mextend
 
 isInherited :: MInclude -> Ident -> Bool
-isInherited c i = case c of
-  MIAll -> True
-  MIOnly is -> elem i is
-  MIExcept is -> notElem i is
+isInherited c =
+  case c of
+    MIAll -> const True
+    MIOnly is -> let is' = Set.fromList is in (`Set.member` is')
+    MIExcept is -> let is' = Set.fromList is in (`Set.notMember` is')
+
 
 inheritAll :: ModuleName -> (ModuleName,MInclude)
 inheritAll i = (i,MIAll)

--- a/src/compiler/GF/Grammar/Grammar.hs
+++ b/src/compiler/GF/Grammar/Grammar.hs
@@ -129,9 +129,17 @@ isInherited :: MInclude -> Ident -> Bool
 isInherited c =
   case c of
     MIAll -> const True
-    MIOnly is -> let is' = Set.fromList is in (`Set.member` is')
-    MIExcept is -> let is' = Set.fromList is in (`Set.notMember` is')
+    MIOnly is -> elemOrd is
+    MIExcept is -> not . elemOrd is
 
+-- | Faster version of `elem`, using a `Set`.
+-- Make sure you give this the first argument _outside_ of the inner loop
+--
+-- Example:
+-- > myIntersection xs ys = filter (elemOrd xs) ys
+elemOrd :: Ord a => [a] -> a -> Bool
+elemOrd list = (`Set.member` set)
+  where set = Set.fromList list
 
 inheritAll :: ModuleName -> (ModuleName,MInclude)
 inheritAll i = (i,MIAll)


### PR DESCRIPTION
When a long list of explicitly included/excluded constants are imported, the performance is `O(n * m)`, where `n` is the number of excluded or included constants and `m` is the total number of constants in the imported module.

This patch uses a `Data.Set` to speed up the check to `O(log(n) * m)`.

For example, this file would take several minutes to load, now it takes less than a second:

```gf
abstract FromWordNet = WordNet [
a_couple_Card,
a_la_carte_Adv,
a_la_mode_Adv,
a_little_Card,
a_lotPl_Card,
a_lotSg_Card,
-- 20 000 lines of words
zone_in_on_V2,
zone_out_V,
zonk_out_1_V,
zonk_out_2_V,
zoom_in_V,
zoom_in_on_V2,
zoom_out_V,
zoophobia_N ] ;
```
