### PR TITLE
Fix ghc-7.10 build

### DIFF
--- a/gf.cabal
+++ b/gf.cabal
@@ -81,12 +81,12 @@ library
     mtl >= 2.2.1 && < 2.3,
     pretty >= 1.1.3 && < 1.2,
     random >= 1.1 && < 1.3,
-    utf8-string >= 1.0.1.1 && < 1.1,
-    -- We need this in order for ghc-7.10 to build
-    transformers-compat >= 0.6.3 && < 0.7
+    utf8-string >= 1.0.1.1 && < 1.1
 
   if impl(ghc<8.0)
     build-depends:
+      -- We need this in order for ghc-7.10 to build
+      transformers-compat >= 0.6.3 && < 0.7,
       fail >= 4.9.0 && < 4.10
 
   hs-source-dirs: src/runtime/haskell

--- a/gf.cabal
+++ b/gf.cabal
@@ -81,7 +81,9 @@ library
     mtl >= 2.2.1 && < 2.3,
     pretty >= 1.1.3 && < 1.2,
     random >= 1.1 && < 1.3,
-    utf8-string >= 1.0.1.1 && < 1.1
+    utf8-string >= 1.0.1.1 && < 1.1,
+    -- We need this in order for ghc-7.10 to build
+    transformers-compat >= 0.6.3 && < 0.7
 
   if impl(ghc<8.0)
     build-depends:

--- a/src/compiler/GF/Interactive.hs
+++ b/src/compiler/GF/Interactive.hs
@@ -38,8 +38,10 @@ import GF.Server(server)
 #endif
 
 import GF.Command.Messages(welcome)
+#if !(MIN_VERSION_base(4,9,0))
 -- Needed to make it compile on GHC < 8
 import Control.Monad.Trans.Instances ()
+#endif
 
 -- | Run the GF Shell in quiet mode (@gf -run@).
 mainRunGFI :: Options -> [FilePath] -> IO ()

--- a/src/compiler/GF/Interactive.hs
+++ b/src/compiler/GF/Interactive.hs
@@ -38,6 +38,8 @@ import GF.Server(server)
 #endif
 
 import GF.Command.Messages(welcome)
+-- Needed to make it compile on GHC < 8
+import Control.Monad.Trans.Instances ()
 
 -- | Run the GF Shell in quiet mode (@gf -run@).
 mainRunGFI :: Options -> [FilePath] -> IO ()

--- a/src/tools/c/GFCC/ErrM.hs
+++ b/src/tools/c/GFCC/ErrM.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
 -- BNF Converter: Error Monad
 -- Copyright (C) 2004  Author:  Aarne Ranta
 
@@ -6,12 +8,17 @@ module GFCC.ErrM where
 
 -- Control.Monad.Fail import will become redundant in GHC 8.8+
 import qualified Control.Monad.Fail as Fail
+import Control.Monad (ap)
 
 
 -- the Error monad: like Maybe type with error msgs
 
 data Err a = Ok a | Bad String
-  deriving (Read, Show, Eq)
+  deriving (Read, Show, Eq, Functor)
+
+instance Applicative Err where
+  pure = Ok
+  (<*>) = ap
 
 instance Monad Err where
   return      = Ok


### PR DESCRIPTION
The build with ghc-7.10.3 was broken by 1294269cd60f3db7b056135104615625baeb528c. This restores it. But this time the compatibility code only imported specifically for ghc < 8, to remove the extra dependency for other versions.