### PR TITLE
Indent each line of error messages

### DIFF
--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -95,8 +95,7 @@ jobs:
 
     - name: Build
       run: |
-        stack build --system-ghc --stack-yaml stack-ghc${{ matrix.ghc }}.yaml
-        # stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+        stack build --test --no-run-tests --system-ghc --stack-yaml stack-ghc${{ matrix.ghc }}.yaml
 
     - name: Test
       run: |

--- a/.github/workflows/build-binary-packages.yml
+++ b/.github/workflows/build-binary-packages.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-18.04
         - ubuntu-20.04
+        - ubuntu-22.04
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/setup-python@v1
       name: Install Python
       with:
-        python-version: '3.7'
+        python-version: '3.x'
 
     - name: Install cibuildwheel
       run: |
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.x'
 
       - name: Build sdist
         run: cd src/runtime/python && python setup.py sdist

--- a/src/compiler/GF/Compile/GetGrammar.hs
+++ b/src/compiler/GF/Compile/GetGrammar.hs
@@ -42,11 +42,12 @@ getSourceModule opts file0 =
      raw <- liftIO $ keepTemp tmp
    --ePutStrLn $ "1 "++file0
      (optCoding,parsed) <- parseSource opts pModDef raw
+     let indentLines = unlines . map ("   "++) . lines
      case parsed of
        Left (Pn l c,msg) -> do file <- liftIO $ writeTemp tmp
                                cwd <- getCurrentDirectory
                                let location = makeRelative cwd file++":"++show l++":"++show c
-                               raise (location++":\n   "++msg)
+                               raise (location++":\n" ++ indentLines msg)
        Right (i,mi0) ->
          do liftIO $ removeTemp tmp
             let mi =mi0 {mflags=mflags mi0 `addOptions` opts, msrc=file0}

--- a/testsuite/compiler/update/ArrityCheck.gfs.gold
+++ b/testsuite/compiler/update/ArrityCheck.gfs.gold
@@ -2,7 +2,8 @@
 
 testsuite/compiler/update/ArrityCheck.gf:6:1:
    conflicting information in module ArrityCheck
-    fun f : Int -> Int -> Int ;
-    def f 0 = \x -> x ;
-and
-    def f 1 1 = 0 ;
+       fun f : Int -> Int -> Int ;
+       def f 0 = \x -> x ;
+   and
+       def f 1 1 = 0 ;
+


### PR DESCRIPTION
Previously only the first line of an error message was indented.

Changing this makes the error messages easier to parse, both for humans and machines. In addition to looking better it would also help making it easier for [gf-lsp](https://github.com/anka-213/gf-lsp/) to show the errors at the correct location

Before:
```
PizzaEng.gf:47:1:
   conflicting information in module PizzaEng
    lin Friends = "friends" ;
and
    lin Friends = "other" ;
```
After
```
PizzaEng.gf:47:1:
   conflicting information in module PizzaEng
       lin Friends = "friends" ;
   and
       lin Friends = "other" ;
```