### PR TITLE
Support GHC 9.4 for the PGF library

### DIFF
--- a/src/runtime/haskell/Data/Binary/Builder.hs
+++ b/src/runtime/haskell/Data/Binary/Builder.hs
@@ -74,13 +74,16 @@ import qualified Data.ByteString.Internal as S
 #endif
 
 #if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-import GHC.Base(Int(..),uncheckedShiftRL# )
+import GHC.Base(Int(..),uncheckedShiftRL#,)
 import GHC.Word (Word32(..),Word16(..),Word64(..))
 
 #if MIN_VERSION_base(4,16,0)
 import GHC.Exts (wordToWord16#, word16ToWord#, wordToWord32#, word32ToWord#)
 #endif
-#if WORD_SIZE_IN_BITS < 64 && __GLASGOW_HASKELL__ >= 608
+#if WORD_SIZE_IN_BITS < 64 && __GLASGOW_HASKELL__ >= 608 
+import GHC.Word (uncheckedShiftRL64#)
+#endif
+#if __GLASGOW_HASKELL__ >= 900 
 import GHC.Word (uncheckedShiftRL64#)
 #endif
 #endif
@@ -433,7 +436,11 @@ foreign import ccall unsafe "stg_uncheckedShiftRL64"
 #endif
 
 #else
+#if __GLASGOW_HASKELL__ <= 810
 shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL#` i)
+#else
+shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL64#` i)
+#endif
 #endif
 
 #else

--- a/src/runtime/haskell/Data/Binary/Get.hs
+++ b/src/runtime/haskell/Data/Binary/Get.hs
@@ -104,6 +104,9 @@ import GHC.Word
 #if MIN_VERSION_base(4,16,0)
 import GHC.Exts (wordToWord16#, word16ToWord#, wordToWord32#, word32ToWord#)
 #endif
+#if __GLASGOW_HASKELL__ >= 900 
+import GHC.Word (uncheckedShiftL64#)
+#endif
 #endif
 
 -- Control.Monad.Fail import will become redundant in GHC 8.8+
@@ -553,7 +556,12 @@ foreign import ccall unsafe "stg_uncheckedShiftL64"
 #endif
 
 #else
+#if __GLASGOW_HASKELL__ <= 810
 shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL#` i)
+#else
+shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL64#` i)
+#endif
+
 #endif
 
 #else

--- a/src/runtime/haskell/pgf.cabal
+++ b/src/runtime/haskell/pgf.cabal
@@ -9,16 +9,16 @@ synopsis: Grammatical Framework
 description: A library for interpreting the Portable Grammar Format (PGF)
 homepage: https://www.grammaticalframework.org/
 bug-reports: https://github.com/GrammaticalFramework/gf-core/issues
-tested-with: GHC==7.10.3, GHC==8.0.2, GHC==8.10.4
+tested-with: GHC==7.10.3, GHC==8.0.2, GHC==8.10.4, GHC==9.4.5
 
 library
   default-language: Haskell2010
   build-depends:
-    array >= 0.5.1 && < 0.6,
-    base >= 4.9.1 && < 4.16,
-    bytestring >= 0.10.8 && < 0.11,
-    containers >= 0.5.7 && < 0.7,
-    ghc-prim >= 0.5.0 && < 0.7,
+    array >= 0.5.1 && < 0.7,
+    base >= 4.9.1 && < 5.0,
+    bytestring >= 0.10.8 && < 0.12,
+    containers >= 0.5.7 && < 0.8,
+    ghc-prim >= 0.5.0 && < 0.10,
     mtl >= 2.2.1 && < 2.3,
     pretty >= 1.1.3 && < 1.2,
     random >= 1.1 && < 1.3,


### PR DESCRIPTION
Bumps some dependencies and adds a couple CPP splices in order to support GHC 9.4.  I didn't see a test suite, but it compiles