### PR TITLE
Fix CI for "Build & Publish Python Package": use python 3.10 instead of latest

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: Build sdist
         run: cd src/runtime/python && python setup.py sdist


### PR DESCRIPTION
The workflow that builds Python package used automatically the latest Python version, but the code requires the `distutils` library, which was removed in Python 3.12. (Source: https://stackoverflow.com/a/77233866) Fixed by changing into explicit requirement for Python 3.10 in the yaml file. 