### PR TITLE
majestic: Type-checking improvements + unifying overload resolution + simple REPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,12 @@ DATA_DIR
 
 stack*.yaml.lock
 
+# Generated source files
+src/compiler/api/GF/Grammar/Lexer.hs
+src/compiler/api/GF/Grammar/Parser.hs
+src/compiler/api/PackageInfo_gf.hs
+src/compiler/api/Paths_gf.hs
+
 # Output files for test suite
 *.out
 gf-tests.html

--- a/src/compiler/api/GF/Compile/Compute/Concrete.hs
+++ b/src/compiler/api/GF/Compile/Compute/Concrete.hs
@@ -1,11 +1,13 @@
-{-# LANGUAGE RankNTypes, BangPatterns, CPP, ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes, BangPatterns, CPP, ExistentialQuantification, LambdaCase #-}
 
 -- | Functions for computing the values of terms in the concrete syntax, in
 -- | preparation for PMCFG generation.
 module GF.Compile.Compute.Concrete
            ( normalForm, normalFlatForm, normalStringForm
            , Value(..), Thunk, ThunkState(..), Env, Scope, showValue
-           , MetaThunks, Constraint, Globals(..), ConstValue(..)
+           , PredefImpl, Predef(..), PredefCombinator, ($\)
+           , pdForce, pdClosedArgs, pdArity, pdStandard
+           , MetaThunks, Constraint, PredefTable, Globals(..), ConstValue(..)
            , EvalM(..), runEvalM, runEvalOneM, reset, evalError, evalWarn
            , eval, apply, force, value2term, patternMatch, stdPredef
            , unsafeIOToEvalM
@@ -26,7 +28,7 @@ import GF.Grammar.Predef
 import GF.Grammar.Lockfield(lockLabel)
 import GF.Grammar.Printer
 import GF.Data.Operations(Err(..))
-import GF.Data.Utilities((<||>),anyM)
+import GF.Data.Utilities(splitAt',(<||>),anyM)
 import GF.Infra.CheckM
 import GF.Infra.Option
 import Data.STRef
@@ -238,15 +240,12 @@ eval env (S t1 t2)      vs  = do v1   <- eval env t1 []
                                    v1           -> return v0
 eval env (Let (x,(_,t1)) t2) vs = do tnk <- newThunk env t1
                                      eval ((x,tnk):env) t2 vs
-eval env (Q q@(m,id))   vs
-  | m == cPredef            = do vs' <- mapM force vs -- FIXME this does not allow for partial application!
-                                 open <- anyM (value2term True [] >=> isOpen []) vs'
-                                 if open then return (VApp q vs) else do
-                                   res <- evalPredef id vs'
-                                   case res of
-                                     Const res -> return res
-                                     RunTime   -> return (VApp q vs)
-                                     NonExist  -> return (VApp (cPredef,cNonExist) [])
+eval env t@(Q q@(m,id)) vs
+  | m == cPredef            = do res <- evalPredef env t id vs
+                                 case res of
+                                   Const res -> return res
+                                   RunTime   -> return (VApp q vs)
+                                   NonExist  -> return (VApp (cPredef,cNonExist) [])
   | otherwise               = do t <- getResDef q
                                  eval env t vs
 eval env (QC q)         vs  = return (VApp q vs)
@@ -326,25 +325,25 @@ apply (VClosure env (Abs b x t)) (v:vs) = eval ((x,v):env) t vs
 apply v                             []  = return v
 
 
-stdPredef :: Map.Map Ident ([Value s] -> EvalM s (ConstValue (Value s)))
+stdPredef :: PredefTable s
 stdPredef = Map.fromList
-  [(cLength, \[v] -> case value2string v of
-                       Const s -> return (Const (VInt (genericLength s)))
-                       _       -> return RunTime)
-  ,(cTake,   \[v1,v2] -> return (fmap string2value (liftA2 genericTake (value2int v1) (value2string v2))))
-  ,(cDrop,   \[v1,v2] -> return (fmap string2value (liftA2 genericDrop (value2int v1) (value2string v2))))
-  ,(cTk,     \[v1,v2] -> return (fmap string2value (liftA2 genericTk (value2int v1) (value2string v2))))
-  ,(cDp,     \[v1,v2] -> return (fmap string2value (liftA2 genericDp (value2int v1) (value2string v2))))
-  ,(cIsUpper,\[v]     -> return (fmap toPBool (liftA (all isUpper) (value2string v))))
-  ,(cToUpper,\[v]     -> return (fmap string2value (liftA (map toUpper) (value2string v))))
-  ,(cToLower,\[v]     -> return (fmap string2value (liftA (map toLower) (value2string v))))
-  ,(cEqStr,  \[v1,v2] -> return (fmap toPBool (liftA2 (==) (value2string v1) (value2string v2))))
-  ,(cOccur,  \[v1,v2] -> return (fmap toPBool (liftA2 occur (value2string v1) (value2string v2))))
-  ,(cOccurs, \[v1,v2] -> return (fmap toPBool (liftA2 occurs (value2string v1) (value2string v2))))
-  ,(cEqInt,  \[v1,v2] -> return (fmap toPBool (liftA2 (==) (value2int v1) (value2int v2))))
-  ,(cLessInt,\[v1,v2] -> return (fmap toPBool (liftA2 (<) (value2int v1) (value2int v2))))
-  ,(cPlus,   \[v1,v2] -> return (fmap VInt (liftA2 (+) (value2int v1) (value2int v2))))
-  ,(cError,  \[v]     -> case value2string v of
+  [(cLength, pdStandard 1 $\ \[v] -> case value2string v of
+                                       Const s -> return (Const (VInt (genericLength s)))
+                                       _       -> return RunTime)
+  ,(cTake,   pdStandard 2 $\ \[v1,v2] -> return (fmap string2value (liftA2 genericTake (value2int v1) (value2string v2))))
+  ,(cDrop,   pdStandard 2 $\ \[v1,v2] -> return (fmap string2value (liftA2 genericDrop (value2int v1) (value2string v2))))
+  ,(cTk,     pdStandard 2 $\ \[v1,v2] -> return (fmap string2value (liftA2 genericTk (value2int v1) (value2string v2))))
+  ,(cDp,     pdStandard 2 $\ \[v1,v2] -> return (fmap string2value (liftA2 genericDp (value2int v1) (value2string v2))))
+  ,(cIsUpper,pdStandard 1 $\ \[v]     -> return (fmap toPBool (liftA (all isUpper) (value2string v))))
+  ,(cToUpper,pdStandard 1 $\ \[v]     -> return (fmap string2value (liftA (map toUpper) (value2string v))))
+  ,(cToLower,pdStandard 1 $\ \[v]     -> return (fmap string2value (liftA (map toLower) (value2string v))))
+  ,(cEqStr,  pdStandard 2 $\ \[v1,v2] -> return (fmap toPBool (liftA2 (==) (value2string v1) (value2string v2))))
+  ,(cOccur,  pdStandard 2 $\ \[v1,v2] -> return (fmap toPBool (liftA2 occur (value2string v1) (value2string v2))))
+  ,(cOccurs, pdStandard 2 $\ \[v1,v2] -> return (fmap toPBool (liftA2 occurs (value2string v1) (value2string v2))))
+  ,(cEqInt,  pdStandard 2 $\ \[v1,v2] -> return (fmap toPBool (liftA2 (==) (value2int v1) (value2int v2))))
+  ,(cLessInt,pdStandard 2 $\ \[v1,v2] -> return (fmap toPBool (liftA2 (<) (value2int v1) (value2int v2))))
+  ,(cPlus,   pdStandard 2 $\ \[v1,v2] -> return (fmap VInt (liftA2 (+) (value2int v1) (value2int v2))))
+  ,(cError,  pdStandard 1 $\ \[v]     -> case value2string v of
                            Const msg -> fail msg
                            _         -> fail "Indescribable error appeared")
   ]
@@ -705,6 +704,16 @@ instance Applicative ConstValue where
   liftA2 f _         RunTime   = RunTime
 #endif
 
+instance Foldable ConstValue where
+  foldr f a (Const x) = f x a
+  foldr f a RunTime   = a
+  foldr f a NonExist  = a
+
+instance Traversable ConstValue where
+  traverse f (Const x) = Const <$> f x
+  traverse f RunTime   = pure RunTime
+  traverse f NonExist  = pure NonExist
+
 value2string v = fmap (\(_,ws,_) -> unwords ws) (value2string' v False [] [])
 
 value2string' (VStr w1)   True (w2:ws) qs = Const (False,(w1++w2):ws,qs)
@@ -763,11 +772,62 @@ value2int (VInt n) = Const n
 value2int _        = RunTime
 
 -----------------------------------------------------------------------
+-- * Global/built-in definitions
+
+type PredefImpl a s = [a] -> EvalM s (ConstValue (Value s))
+newtype Predef a s = Predef { runPredef :: Term -> Env s -> PredefImpl a s }
+type PredefCombinator a b s = Predef a s -> Predef b s
+
+infix 0 $\\
+
+($\) :: PredefCombinator a b s -> PredefImpl a s -> Predef b s
+k $\ f = k (Predef (\_ _ -> f))
+
+pdForce :: PredefCombinator (Value s) (Thunk s) s
+pdForce def = Predef $ \h env args -> do
+  argValues <- mapM force args
+  runPredef def h env argValues
+
+pdClosedArgs :: PredefCombinator (Value s) (Value s) s
+pdClosedArgs def = Predef $ \h env args -> do
+  open <- anyM (value2term True [] >=> isOpen []) args
+  if open then return RunTime else runPredef def h env args
+
+pdArity :: Int -> PredefCombinator (Thunk s) (Thunk s) s
+pdArity n def = Predef $ \h env args ->
+  case splitAt' n args of
+    Nothing -> do
+      t <- papply env h args
+      let t' = abstract 0 (n - length args) t
+      Const <$> eval env t' []
+    Just (usedArgs, remArgs) -> do
+      res <- runPredef def h env usedArgs
+      forM res $ \v -> case remArgs of
+        [] -> return v
+        _  -> do
+          t <- value2term False (fst <$> env) v
+          eval env t remArgs
+  where
+    papply env t []         = return t
+    papply env t (arg:args) = do
+      arg <- tnk2term False (fst <$> env) arg
+      papply env (App t arg) args
+    
+    abstract i n t
+      | n <= 0    = t
+      | otherwise = let x = identV (rawIdentS "a") i
+                    in  Abs Explicit x (abstract (i + 1) (n - 1) (App t (Vr x)))
+
+pdStandard :: Int -> PredefCombinator (Value s) (Thunk s) s
+pdStandard n = pdArity n . pdForce . pdClosedArgs
+
+-----------------------------------------------------------------------
 -- * Evaluation monad
 
 type MetaThunks s = Map.Map MetaId (Thunk s)
 type Cont s r = MetaThunks s -> Int -> r -> [Message] -> ST s (CheckResult r [Message])
-data Globals = Gl Grammar (forall s . Map.Map Ident ([Value s] -> EvalM s (ConstValue (Value s))))
+type PredefTable s = Map.Map Ident (Predef (Thunk s) s)
+data Globals = Gl Grammar (forall s . PredefTable s)
 newtype EvalM s a = EvalM (forall r . Globals -> (a -> Cont s r) -> Cont s r)
 
 instance Functor (EvalM s) where
@@ -826,9 +886,9 @@ evalError msg = EvalM (\gr k _ _ r msgs -> return (Fail msg msgs))
 evalWarn :: Message -> EvalM s ()
 evalWarn msg = EvalM (\gr k mt d r msgs -> k () mt d r (msg:msgs))
 
-evalPredef :: Ident -> [Value s] -> EvalM s (ConstValue (Value s))
-evalPredef id vs = EvalM (\globals@(Gl _ predef) k mt d r msgs ->
-  case fmap (\f -> f vs) (Map.lookup id predef) of
+evalPredef :: Env s -> Term -> Ident -> [Thunk s] -> EvalM s (ConstValue (Value s))
+evalPredef env h id args = EvalM (\globals@(Gl _ predef) k mt d r msgs ->
+  case fmap (\def -> runPredef def h env args) (Map.lookup id predef) of
     Just (EvalM f) -> f globals k mt d r msgs
     Nothing        -> k RunTime mt d r msgs)
 

--- a/src/compiler/api/GF/Compile/Repl.hs
+++ b/src/compiler/api/GF/Compile/Repl.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE LambdaCase #-}
+
+module GF.Compile.Repl (ReplOpts(..), defaultReplOpts, replOptDescrs, getReplOpts, runRepl, runRepl') where
+
+import Control.Monad (unless, forM_)
+import Control.Monad.IO.Class (MonadIO)
+import Data.Char (isSpace)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Map as Map
+
+import System.Console.GetOpt (getOpt, ArgOrder(RequireOrder), OptDescr(..), ArgDescr(..))
+import System.Console.Haskeline (InputT, Settings(..), noCompletion, runInputT, getInputLine, outputStrLn)
+import System.Directory (getAppUserDataDirectory)
+
+import GF.Compile (batchCompile)
+import GF.Compile.Compute.Concrete (Globals(Gl), normalFlatForm)
+import GF.Compile.Rename (renameSourceTerm)
+import GF.Compile.TypeCheck.ConcreteNew (inferLType)
+import GF.Data.ErrM (Err(..))
+import GF.Grammar.Grammar
+  ( Grammar
+  , mGrammar
+  , Info
+  , Module
+  , ModuleName
+  , ModuleInfo(..)
+  , ModuleType(MTResource)
+  , ModuleStatus(MSComplete)
+  , OpenSpec(OSimple)
+  , Location (NoLoc)
+  , Term
+  , prependModule
+  )
+import GF.Grammar.Lexer (Posn(..), Lang(GF), runLangP)
+import GF.Grammar.Parser (pTerm)
+import GF.Grammar.Printer (TermPrintQual(Unqualified), ppTerm)
+import GF.Infra.CheckM (Check, runCheck)
+import GF.Infra.Ident (moduleNameS)
+import GF.Infra.Option (noOptions)
+import GF.Text.Pretty (render)
+
+data ReplOpts = ReplOpts
+  { noPrelude :: Bool
+  , inputFiles :: [String]
+  }
+
+defaultReplOpts :: ReplOpts
+defaultReplOpts = ReplOpts False []
+
+replOptDescrs :: [OptDescr (ReplOpts -> ReplOpts)]
+replOptDescrs =
+  [ Option [] ["no-prelude"] (NoArg $ \o -> o { noPrelude = True }) "Don't load the prelude."
+  ]
+
+getReplOpts :: [String] -> Either [String] ReplOpts
+getReplOpts args = case errs of
+  [] -> Right $ (foldr ($) defaultReplOpts flags) { inputFiles = inputFiles }
+  _  -> Left errs
+  where
+    (flags, inputFiles, errs) = getOpt RequireOrder [] args
+
+execCheck :: MonadIO m => Check a -> (a -> InputT m ()) -> InputT m ()
+execCheck c k = case runCheck c of
+  Ok (a, warn) -> do
+    unless (null warn) $ outputStrLn warn
+    k a
+  Bad err -> outputStrLn err
+
+replModNameStr :: String
+replModNameStr = "<repl>"
+
+replModName :: ModuleName
+replModName = moduleNameS replModNameStr
+
+parseThen :: MonadIO m => Grammar -> String -> (Term -> InputT m ()) -> InputT m ()
+parseThen g s k = case runLangP GF pTerm (BS.pack s) of
+  Left (Pn l c, err) -> outputStrLn $ err ++ " (" ++ show l ++ ":" ++ show c ++ ")"
+  Right t -> execCheck (renameSourceTerm g replModName t) $ \t -> k t
+
+runRepl' :: Globals -> IO ()
+runRepl' gl@(Gl g _) = do
+  historyFile <- getAppUserDataDirectory "gfci_history"
+  runInputT (Settings noCompletion (Just historyFile) True) repl -- TODO tab completion
+  where
+    repl = do
+      getInputLine "gfci> " >>= \case
+        Nothing -> repl
+        Just (':' : l) -> let (cmd, arg) = break isSpace l in command cmd (dropWhile isSpace arg)
+        Just code -> evalPrintLoop code
+
+    command "t" arg = do
+      parseThen g arg $ \main ->
+        execCheck (inferLType gl main) $ \(_, ty) ->
+          outputStrLn $ render (ppTerm Unqualified 0 ty)
+      outputStrLn "" >> repl
+    
+    command "q" _ = outputStrLn "Bye!"
+
+    command cmd _ = do
+      outputStrLn $ "Unknown REPL command: " ++ cmd
+      outputStrLn "" >> repl
+
+    evalPrintLoop code = do -- TODO bindings
+      parseThen g code $ \main ->
+        execCheck (inferLType gl main >>= \(t, _) -> normalFlatForm gl t) $ \nfs ->
+          forM_ (zip [1..] nfs) $ \(i, nf) ->
+            outputStrLn $ show i ++ ". " ++ render (ppTerm Unqualified 0 nf)
+      outputStrLn "" >> repl
+
+runRepl :: ReplOpts -> IO ()
+runRepl (ReplOpts noPrelude inputFiles) = do
+  -- TODO accept an ngf grammar
+  -- TODO load prelude
+  (g0, opens) <- case inputFiles of
+    [] -> pure (mGrammar [], [])
+    _ -> do
+      (_, (pModName, g0)) <- batchCompile noOptions Nothing inputFiles
+      pure (g0, [OSimple pModName])
+  let
+    modInfo = ModInfo
+      { mtype   = MTResource
+      , mstatus = MSComplete
+      , mflags  = noOptions
+      , mextend = []
+      , mwith   = Nothing
+      , mopens  = opens
+      , mexdeps = []
+      , msrc    = replModNameStr
+      , mseqs   = Nothing
+      , jments  = Map.empty
+      }
+  runRepl' (Gl (prependModule g0 (replModName, modInfo)) Map.empty)

--- a/src/compiler/api/GF/Data/Utilities.hs
+++ b/src/compiler/api/GF/Data/Utilities.hs
@@ -16,7 +16,7 @@ module GF.Data.Utilities(module GF.Data.Utilities) where
 
 import Data.Maybe
 import Data.List
-import Control.Monad (MonadPlus(..),liftM,when)
+import Control.Monad (MonadPlus(..),foldM,liftM,when)
 import qualified Data.Set as Set
 
 -- * functions on lists
@@ -139,6 +139,25 @@ whenMP b x = if b then return x else mzero
 whenM bm m = flip when m =<< bm
 
 repeatM m = whenM m (repeatM m)
+
+infixr 3 <&&>
+infixr 2 <||>
+
+-- | Boolean conjunction lifted to applicative functors.
+(<&&>) :: Applicative f => f Bool -> f Bool -> f Bool
+(<&&>) = liftA2 (&&)
+
+-- | Boolean disjunction lifted to applicative functors.
+(<||>) :: Applicative f => f Bool -> f Bool -> f Bool
+(<||>) = liftA2 (||)
+
+-- | Check whether a monadic predicate holds for every element of a collection.
+allM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+allM p = foldM (\b x -> if b then p x else return False) True
+
+-- | Check whether a monadic predicate holds for any element of a collection.
+anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
+anyM p = foldM (\b x -> if b then return True else p x) False
 
 -- * functions on Maybes
 

--- a/src/compiler/api/GF/Data/Utilities.hs
+++ b/src/compiler/api/GF/Data/Utilities.hs
@@ -14,6 +14,7 @@
 
 module GF.Data.Utilities(module GF.Data.Utilities) where
 
+import Data.Bifunctor (first)
 import Data.Maybe
 import Data.List
 import Control.Monad (MonadPlus(..),foldM,liftM,when)
@@ -44,6 +45,14 @@ splitBy :: (a -> Bool) -> [a] -> ([a], [a])
 splitBy p [] = ([], [])
 splitBy p (a : as) = if p a then (a:xs, ys) else (xs, a:ys)
     where (xs, ys) = splitBy p as
+
+splitAt' :: Int -> [a] -> Maybe ([a], [a])
+splitAt' n xs
+    | n <= 0    = Just ([], xs)
+    | otherwise = helper n xs
+    where helper 0 xs     = Just ([], xs)
+          helper n []     = Nothing
+          helper n (x:xs) = first (x:) <$> helper (n - 1) xs
 
 foldMerge :: (a -> a -> a) -> a -> [a] -> a
 foldMerge merge zero = fm

--- a/src/compiler/api/GF/Interactive.hs
+++ b/src/compiler/api/GF/Interactive.hs
@@ -39,6 +39,7 @@ import qualified Data.Sequence as Seq
 import qualified Text.ParserCombinators.ReadP as RP
 import System.Directory(getAppUserDataDirectory)
 import Control.Exception(SomeException,fromException,evaluate,try)
+import Control.Monad ((<=<),when,mplus,join)
 import Control.Monad.State hiding (void)
 import qualified GF.System.Signal as IO(runInterruptibly)
 import GF.Command.Messages(welcome)

--- a/src/compiler/api/GF/Term.hs
+++ b/src/compiler/api/GF/Term.hs
@@ -2,7 +2,7 @@ module GF.Term (renameSourceTerm,
                 Globals(..), ConstValue(..), EvalM, stdPredef,
                 Value(..), showValue, Thunk, newThunk, newEvaluatedThunk,
                 evalError, evalWarn,
-                inferLType, checkLType,
+                inferLType, inferLType', checkLType, checkLType',
                 normalForm, normalFlatForm, normalStringForm,
                 unsafeIOToEvalM, force
                ) where

--- a/src/compiler/gf-repl.hs
+++ b/src/compiler/gf-repl.hs
@@ -1,0 +1,12 @@
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
+
+import System.Environment (getArgs)
+import GF.Compile.Repl (getReplOpts, runRepl)
+
+main :: IO ()
+main = do
+  setLocaleEncoding utf8
+  args <- getArgs
+  case getReplOpts args of
+    Left errs  -> mapM_ print errs
+    Right opts -> runRepl opts

--- a/src/compiler/gf-repl.hs
+++ b/src/compiler/gf-repl.hs
@@ -8,5 +8,5 @@ main = do
   setLocaleEncoding utf8
   args <- getArgs
   case getReplOpts args of
-    Left errs  -> mapM_ print errs
+    Left errs  -> mapM_ putStrLn errs
     Right opts -> runRepl opts

--- a/src/compiler/gf.cabal
+++ b/src/compiler/gf.cabal
@@ -70,6 +70,8 @@ library
                  ghc-prim,
                  filepath, directory>=1.2, time,
                  process, haskeline, parallel>=3, json
+  build-tool-depends: alex:alex >= 3.2.4,
+                      happy:happy >= 1.19.9
   exposed-modules:
     GF.Interactive
     GF.Compiler
@@ -200,7 +202,7 @@ library
   else
     build-depends:
       terminfo >=0.4.0 && < 0.5,
-      unix >= 2.7.2 && < 2.8
+      unix >= 2.7.2 && < 2.9
 
   if flag(server)
     build-depends:

--- a/src/compiler/gf.cabal
+++ b/src/compiler/gf.cabal
@@ -122,6 +122,7 @@ library
     GF.Grammar.CanonicalJSON
     GF.Compile.ReadFiles
     GF.Compile.Rename
+    GF.Compile.Repl
     GF.Compile.SubExOpt
     GF.Compile.Tags
     GF.Compile.ToAPI
@@ -237,6 +238,12 @@ executable gf
       Paths_gf
   default-language:    Haskell2010
   build-depends: base >= 4.6 && <5, directory>=1.2, gf
+  ghc-options: -threaded
+
+executable gfci
+  main-is: gf-repl.hs
+  default-language: Haskell2010
+  build-depends: base >= 4.6 && < 5, gf
   ghc-options: -threaded
 
 test-suite gf-tests


### PR DESCRIPTION
Brief summary of changes:

* Registers `alex` and `happy` as Cabal build tools so `cabal2nix` can pick them up properly
* Fixed crash when type-checking non-dependent products
* Fixed builtins being called with free variables during type checking
* Added variants of `checkLType` and `inferLType` that run inside `EvalM` (i.e. are not trapped inside a `runEvalOneM`)
* Added a simple REPL executable (`gfci`) for working with the GF programming language
* Allows overload resolution to match more than one overload (e.g. when applied to a term with unknown type as in `\x -> foo x`)
  * The unfoldings of the matching overloads are bundled into a `variants` expression which is typed with the unifier of all the overloads' RHS types

Supervised by @krangelov 