### PR TITLE
majestic: predef evaluation + option..of construct

### DIFF
--- a/src/compiler/api/GF/Compile/CheckGrammar.hs
+++ b/src/compiler/api/GF/Compile/CheckGrammar.hs
@@ -302,7 +302,7 @@ checkInfo opts cwd sgr sm (c,info) = checkInModule cwd (snd sm) NoLoc empty $ do
 -- | for grammars obtained otherwise than by parsing ---- update!!
 checkReservedId :: Ident -> Check ()
 checkReservedId x =
-  when (isReservedWord x) $
+  when (isReservedWord GF x) $
        checkWarn ("reserved word used as identifier:" <+> x)
 
 -- auxiliaries

--- a/src/compiler/api/GF/Compile/Compute/Concrete.hs
+++ b/src/compiler/api/GF/Compile/Compute/Concrete.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RankNTypes, BangPatterns, CPP, ExistentialQuantification, LambdaCase #-}
+{-# LANGUAGE RankNTypes, BangPatterns, CPP, ExistentialQuantification #-}
 
 -- | Functions for computing the values of terms in the concrete syntax, in
 -- | preparation for PMCFG generation.
@@ -297,6 +297,10 @@ eval env (TSymCat d r rs) []= do rs <- forM rs $ \(i,(pv,ty)) ->
                                            Nothing  -> evalError ("Variable" <+> pp pv <+> "is not in scope")
                                  return (VSymCat d r rs)
 eval env (TSymVar d r)  []  = do return (VSymVar d r)
+eval env t@(Opts n cs)  vs  = EvalM $ \gr k e mt b r msgs ->
+  case cs of
+    []        -> return $ Fail ("No options in expression:" $$ ppTerm Unqualified 0 t) msgs
+    ((l,t):_) -> case eval env t vs of EvalM f -> f gr k e mt b r msgs
 eval env t              vs  = evalError ("Cannot reduce term" <+> pp t)
 
 apply v                             []  = return v

--- a/src/compiler/api/GF/Compile/Repl.hs
+++ b/src/compiler/api/GF/Compile/Repl.hs
@@ -1,24 +1,40 @@
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE LambdaCase, TupleSections, NamedFieldPuns #-}
 
 module GF.Compile.Repl (ReplOpts(..), defaultReplOpts, replOptDescrs, getReplOpts, runRepl, runRepl') where
 
-import Control.Monad (unless, forM_, foldM)
+import Control.Monad (join, when, unless, forM_, foldM)
 import Control.Monad.IO.Class (MonadIO)
 import qualified Data.ByteString.Char8 as BS
 import Data.Char (isSpace)
 import Data.Function ((&))
 import Data.Functor ((<&>))
+import Data.List (find)
 import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Text.Read (readMaybe)
 
 import System.Console.GetOpt (ArgOrder(RequireOrder), OptDescr(..), ArgDescr(..), getOpt, usageInfo)
 import System.Console.Haskeline (InputT, Settings(..), noCompletion, runInputT, getInputLine, outputStrLn)
 import System.Directory (getAppUserDataDirectory)
 
 import GF.Compile (batchCompile)
-import GF.Compile.Compute.Concrete2 (Globals(Gl), stdPredef, normalFlatForm)
+import GF.Compile.Compute.Concrete2
+  ( Choice(..)
+  , ChoiceMap
+  , Globals(Gl)
+  , OptionInfo(..)
+  , stdPredef
+  , unit
+  , eval
+  , cleanOptions
+  , runEvalMWithOpts
+  , value2termM
+  , ppValue
+  )
 import GF.Compile.Rename (renameSourceTerm)
 import GF.Compile.TypeCheck.ConcreteNew (inferLType)
 import GF.Data.ErrM (Err(..))
+import GF.Data.Utilities (maybeAt, orLeft)
 import GF.Grammar.Grammar
   ( Grammar
   , mGrammar
@@ -47,10 +63,16 @@ data ReplOpts = ReplOpts
   { lang :: Lang
   , noPrelude :: Bool
   , inputFiles :: [String]
+  , evalToFlat :: Bool
   }
 
 defaultReplOpts :: ReplOpts
-defaultReplOpts = ReplOpts GF False []
+defaultReplOpts = ReplOpts
+  { lang = GF
+  , noPrelude = False
+  , inputFiles = []
+  , evalToFlat = True
+  }
 
 type Errs a = Either [String] a
 type ReplOptsOp = ReplOpts -> Errs ReplOpts
@@ -66,6 +88,7 @@ replOptDescrs =
                                           _      -> Left ["Unknown language variant: " ++ s])
                                "{gf,bnfc,nlg}")
            "Set the active language variant."
+  , Option [] ["no-flat"] (flag $ \o -> o { evalToFlat = False }) "Do not evaluate to flat form."
   ]
   where
     flag f = NoArg $ \o -> pure (f o)
@@ -77,12 +100,14 @@ getReplOpts args = case errs of
   where
     (flags, inputFiles, errs) = getOpt RequireOrder replOptDescrs args
 
-execCheck :: MonadIO m => Check a -> (a -> InputT m ()) -> InputT m ()
+execCheck :: MonadIO m => Check a -> (a -> InputT m b) -> InputT m (Maybe b)
 execCheck c k = case runCheck c of
   Ok (a, warn) -> do
     unless (null warn) $ outputStrLn warn
-    k a
-  Bad err -> outputStrLn err
+    Just <$> k a
+  Bad err -> do
+    outputStrLn err
+    return Nothing
 
 replModNameStr :: String
 replModNameStr = "<repl>"
@@ -90,47 +115,182 @@ replModNameStr = "<repl>"
 replModName :: ModuleName
 replModName = moduleNameS replModNameStr
 
-parseThen :: MonadIO m => Lang -> Grammar -> String -> (Term -> InputT m ()) -> InputT m ()
+parseThen :: MonadIO m => Lang -> Grammar -> String -> (Term -> InputT m b) -> InputT m (Maybe b)
 parseThen l g s k = case runLangP l pTerm (BS.pack s) of
-  Left (Pn l c, err) -> outputStrLn $ err ++ " (" ++ show l ++ ":" ++ show c ++ ")"
+  Left (Pn l c, err) -> do
+    outputStrLn $ err ++ " (" ++ show l ++ ":" ++ show c ++ ")"
+    return Nothing
   Right t -> execCheck (renameSourceTerm g replModName t) $ \t -> k t
 
-runRepl' :: Lang -> Globals -> IO ()
-runRepl' l gl@(Gl g _) = do
-  historyFile <- getAppUserDataDirectory "gfci_history"
-  runInputT (Settings noCompletion (Just historyFile) True) repl -- TODO tab completion
-  where
-    repl = do
-      getInputLine "gfci> " >>= \case
-        Nothing -> repl
-        Just (':' : l) -> let (cmd, arg) = break isSpace l in command cmd (dropWhile isSpace arg)
-        Just code -> evalPrintLoop code
+data ResultState = ResultState
+  { srsResult  :: Term
+  , srsChoices :: ChoiceMap
+  , srsOptInfo :: [OptionInfo]
+  , srsOpts    :: ChoiceMap
+  }
+data OptionState = OptionState
+  { osTerm     :: Term
+  , osResults  :: [ResultState]
+  , osSelected :: Maybe ResultState
+  }
+newtype ReplState = ReplState
+  { rsOpts :: Maybe OptionState
+  }
 
-    command "t" arg = do
-      parseThen l g arg $ \main ->
+initState :: ReplState
+initState = ReplState Nothing
+
+runRepl' :: ReplOpts -> Globals -> IO ()
+runRepl' opts@ReplOpts { lang, evalToFlat } gl@(Gl g _) = do
+  historyFile <- getAppUserDataDirectory "gfci_history"
+  runInputT (Settings noCompletion (Just historyFile) True) (repl initState) -- TODO tab completion
+  where
+    repl st = do
+      getInputLine "gfci> " >>= \case
+        Nothing -> repl st
+        Just (':' : l) -> let (cmd, arg) = break isSpace l in command st cmd (dropWhile isSpace arg)
+        Just code -> evalPrintLoop st code
+
+    nlrepl st = outputStrLn "" >> repl st
+
+    -- Show help text
+    command st "?" arg = do
+      outputStrLn ":? -- show help text."
+      outputStrLn ":t <expr> -- show the inferred type of <expr>."
+      outputStrLn ":r -- show the results of the last eval."
+      outputStrLn ":s <index> -- select the result at <index>."
+      outputStrLn ":c -- show the current selected result."
+      outputStrLn ":o <choice> <value> -- set option <choice> to <value>."
+      outputStrLn ":q -- quit the REPL."
+      nlrepl st
+
+    -- Show the inferred type of an expression
+    command st "t" arg = do
+      parseThen lang g arg $ \main ->
         execCheck (inferLType gl main) $ \res ->
           forM_ res $ \(t, ty) ->
             let t' = case t of
                        Typed _ _ -> t
                        t         -> Typed t ty
             in outputStrLn $ render (ppTerm Unqualified 0 t')
-      outputStrLn "" >> repl
+      nlrepl st
     
-    command "q" _ = outputStrLn "Bye!"
+    -- Show the results of the last evaluated expression
+    command st "r" arg = do
+      case rsOpts st of
+        Nothing -> do
+          outputStrLn "No results to show!"
+        Just (OptionState t rs _) -> do
+          outputStrLn $ "> " ++ render (ppTerm Unqualified 0 t)
+          outputResults rs
+      nlrepl st
 
-    command cmd _ = do
-      outputStrLn $ "Unknown REPL command: " ++ cmd
-      outputStrLn "" >> repl
+    -- Select a result to "focus" by its index
+    command st "s" arg = do
+      let e = do (OptionState t rs _) <- orLeft "No results to select!" $ rsOpts st
+                 s <- orLeft "Could not parse result index!" $ readMaybe arg
+                 (ResultState r cs ois os) <- orLeft "Result index out of bounds!" $ rs `maybeAt` (s - 1)
+                 return (t, rs, r, cs, ois, os)
+      case e of
+        Left err -> do
+          outputStrLn err
+          nlrepl st
+        Right (t, rs, r, cs, ois, os) -> do
+          outputStrLn $ render (ppTerm Unqualified 0 r)
+          outputOptions ois os
+          nlrepl (st { rsOpts = Just (OptionState t rs (Just (ResultState r cs ois os))) })
 
-    evalPrintLoop code = do -- TODO bindings
-      parseThen l g code $ \main ->
-        execCheck (inferLType gl main >>= \((t, _):_) -> normalFlatForm gl t) $ \nfs ->
-          forM_ (zip [1..] nfs) $ \(i, nf) ->
-            outputStrLn $ show i ++ ". " ++ render (ppTerm Unqualified 0 nf)
-      outputStrLn "" >> repl
+    -- Show the current selected result
+    command st "c" arg = do
+      let e = do (OptionState t _ sel) <- orLeft "No results to select!" $ rsOpts st
+                 (ResultState r _ ois os) <- orLeft "No result selected!" sel
+                 return (t, r, ois, os)
+      case e of
+        Left err -> outputStrLn err
+        Right (t, r, ois, os) -> do
+          outputStrLn $ "> " ++ render (ppTerm Unqualified 0 t)
+          outputStrLn $ render (ppTerm Unqualified 0 r)
+          outputOptions ois os
+      nlrepl st
+
+    -- Set an option for the selected result
+    command st "o" arg = do
+      let e = do (OptionState t _ sel) <- orLeft "No results to select!" $ rsOpts st
+                 (ResultState _ cs ois os) <- orLeft "No result selected!" sel
+                 (c, i) <- case words arg of
+                             [argc, argi] -> do
+                               c <- orLeft "Could not parse option choice!" $ readMaybe argc
+                               i <- orLeft "Could not parse option value!" $ readMaybe argi
+                               return (c, i)
+                             _ -> Left "Expected two arguments!"
+                 when (i < 1) $ Left "Option value must be positive!"
+                 oi <- orLeft "No such option!" $ find (\oi -> unchoice (optChoice oi) == c) ois
+                 when (i > length (optChoices oi)) $ Left "Option value out of bounds!"
+                 return (t, cs, ois, os, c, i)
+      case e of
+        Left err -> do
+          outputStrLn err
+          nlrepl st
+        Right (t, cs, ois, os, c, i) -> do
+          let os' = Map.insert (Choice c) (i - 1) os
+          nfs <- execCheck (doEval st t (Map.union os' cs)) pure
+          case nfs of
+            Nothing -> nlrepl st
+            Just [] -> do
+              outputStrLn "No results!"
+              nlrepl st
+            Just [(r, cs, ois')] -> do
+              outputStrLn $ render (ppTerm Unqualified 0 r)
+              let os'' = cleanOptions ois' os'
+              outputOptions ois' os''
+              let rst = ResultState r (Map.difference cs os') ois' os''
+              nlrepl (st { rsOpts = Just (OptionState t [rst] (Just rst)) })
+            Just rs -> do
+              let rsts = rs <&> \(r, cs, ois') ->
+                           ResultState r (Map.difference cs os') ois' (cleanOptions ois' os')
+              outputResults rsts
+              nlrepl (st { rsOpts = Just (OptionState t rsts Nothing) })
+    
+    -- Quit the REPL
+    command _ "q" _ = outputStrLn "Bye!"
+
+    command st cmd _ = do
+      outputStrLn $ "Unknown REPL command \"" ++ cmd ++ "\"! Use :? for help."
+      nlrepl st
+
+    evalPrintLoop st code = do -- TODO bindings
+      c <- parseThen lang g code $ \main -> do
+        rsts <- execCheck (doEval st main Map.empty) $ \nfs -> do
+          if null nfs then do
+            outputStrLn "No results!"
+            return Nothing
+          else do
+            let rsts = nfs <&> \(r, cs, ois) -> ResultState r cs ois Map.empty
+            outputResults rsts
+            return $ Just rsts
+        return $ (main,) <$> join rsts
+      case join c of
+        Just (t, rs) -> nlrepl (ReplState (Just (OptionState t rs Nothing)))
+        Nothing      -> nlrepl st
+
+    doEval st t opts = inferLType gl t >>= \case
+      []          -> fail $ "No result while checking type: " ++ render (ppTerm Unqualified 0 t)
+      ((t', _):_) -> runEvalMWithOpts gl opts (value2termM evalToFlat [] (eval gl [] unit t' []))
+    
+    outputResults rs =
+      forM_ (zip [1..] rs) $ \(i, ResultState r _ opts _) ->
+        outputStrLn $ show i ++ (if null opts then ". " else "*. ") ++ render (ppTerm Unqualified 0 r)
+    
+    outputOptions ois os =
+      forM_ ois $ \(OptionInfo c n ls) -> do
+        outputStrLn ""
+        outputStrLn $ show (unchoice c) ++ ") " ++ render (ppValue Unqualified 0 n)
+        let sel = fromMaybe 0 (Map.lookup c os) + 1
+        forM_ (zip [1..] ls) $ \(i, l) ->
+          outputStrLn $ (if i == sel then "->" else "  ") ++ show i ++ ". " ++ render (ppValue Unqualified 0 l)
 
 runRepl :: ReplOpts -> IO ()
-runRepl (ReplOpts lang noPrelude inputFiles) = do
+runRepl opts@ReplOpts { noPrelude, inputFiles } = do
   -- TODO accept an ngf grammar
   let toLoad = if noPrelude then inputFiles else "prelude/Predef.gfo" : inputFiles
   (g0, opens) <- case toLoad of
@@ -152,4 +312,4 @@ runRepl (ReplOpts lang noPrelude inputFiles) = do
       , jments  = Map.empty
       }
     g = Gl (prependModule g0 (replModName, modInfo)) (if noPrelude then Map.empty else stdPredef g)
-  runRepl' lang g
+  runRepl' opts g

--- a/src/compiler/api/GF/Data/Utilities.hs
+++ b/src/compiler/api/GF/Data/Utilities.hs
@@ -32,6 +32,11 @@ notLongerThan, longerThan :: Int -> [a] -> Bool
 notLongerThan n = null . snd . splitAt n
 longerThan    n = not . notLongerThan n
 
+maybeAt :: [a] -> Int -> Maybe a
+maybeAt xs i
+    | i >= 0 && i < length xs = Just (xs !! i)
+    | otherwise               = Nothing
+
 lookupList :: Eq a => a -> [(a, b)] -> [b]
 lookupList a [] = []
 lookupList a (p:ps) | a == fst p = snd p : lookupList a ps
@@ -170,6 +175,11 @@ anyM :: (Foldable f, Monad m) => (a -> m Bool) -> f a -> m Bool
 anyM p = foldM (\b x -> if b then return True else p x) False
 
 -- * functions on Maybes
+
+-- | Returns the argument on the right, or a default value on the left.
+orLeft :: a -> Maybe b -> Either a b
+orLeft a (Just b) = Right b
+orLeft a Nothing  = Left a
 
 -- | Returns true if the argument is Nothing or Just []
 nothingOrNull :: Maybe [a] -> Bool

--- a/src/compiler/api/GF/Grammar/Grammar.hs
+++ b/src/compiler/api/GF/Grammar/Grammar.hs
@@ -54,6 +54,7 @@ module GF.Grammar.Grammar (
         Equation,
         Labelling,
         Assign,
+        Option,
         Case,
         LocalDef,
         Param,
@@ -372,7 +373,9 @@ data Term =
  | R [Assign]                    -- ^ record:      @{ p = a ; ...}@
  | P Term Label                  -- ^ projection:  @r.p@
  | ExtR Term Term                -- ^ extension:   @R ** {x : A}@ (both types and terms)
- 
+
+ | Opts Term [Option]            -- ^ options:     @options s in { e => x ; ... }@
+
  | Table Term Term               -- ^ table type:  @P => A@
  | T TInfo [Case]                -- ^ table:       @table {p => c ; ...}@
  | V Type [Term]                 -- ^ table given as course of values: @table T [c1 ; ... ; cn]@
@@ -471,6 +474,7 @@ type Equation = ([Patt],Term)
 
 type Labelling = (Label, Type) 
 type Assign = (Label, (Maybe Type, Term)) 
+type Option = (Term, Term)
 type Case = (Patt, Term) 
 --type Cases = ([Patt], Term) 
 type LocalDef = (Ident, (Maybe Type, Term))

--- a/src/compiler/api/GF/Grammar/Parser.y
+++ b/src/compiler/api/GF/Grammar/Parser.y
@@ -101,6 +101,7 @@ import qualified Data.Map as Map
  'of'         { T_of        }
  'open'       { T_open      }
  'oper'       { T_oper      }
+ 'option'     { T_option    }
  'param'      { T_param     }
  'pattern'    { T_pattern   }
  'pre'        { T_pre       }
@@ -452,6 +453,7 @@ Exp4 :: { Term }
 Exp4
   : Exp4 Exp5                        { App $1 $2 }
   | Exp4 '{' Exp '}'                 { App $1 (ImplArg $3) } 
+  | 'option' Exp 'of' '{' ListOpt '}' { Opts $2 $5 }
   | 'case' Exp 'of' '{' ListCase '}' { let annot = case $2 of
                                              Typed _ t -> TTyped t
                                              _         -> TRaw
@@ -607,6 +609,15 @@ ListPattTupleComp
   : {- empty -}                { []      } 
   | Patt                       { [$1]    }
   | Patt ',' ListPattTupleComp { $1 : $3 }
+
+Opt :: { Option }
+Opt
+  : '(' Exp ')' '=>' Exp { ($2,$5) }
+
+ListOpt :: { [Option] }
+ListOpt
+  : Opt             { [$1]    }
+  | Opt ';' ListOpt { $1 : $3 }
 
 Case :: { Case }
 Case


### PR DESCRIPTION
This PR:

* Applies the discussed predef evaluation fixes to the new evaluator
* Adds the canonical-form predef combinator
* Adds parser support for the `option..of` construct
* Adds a `VFV` case for option selections (analogously for `CFV`)
* Adds support for rudimentary option selection to the gfci repl