### PR TITLE
try if upload to PyPI works when PR comes from the same repo

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -75,7 +75,8 @@ jobs:
     name: Upload to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+#    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -97,6 +97,8 @@ jobs:
       - name: Publish
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          (cd ./src/runtime/python && curl -I --fail https://pypi.org/project/$(python setup.py --name)/$(python setup.py --version)/) || twine upload dist/*
+          ls -la ./dist/  # Debug: Check if wheels exist
+          echo "Attempting upload..."
+          twine upload --verbose --non-interactive --skip-existing dist/*

--- a/src/runtime/python/setup.py
+++ b/src/runtime/python/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os
 
 includes = os.getenv('EXTRA_INCLUDE_DIRS','').split(':')
@@ -16,7 +16,7 @@ pgf_module = Extension('pgf',
                        libraries = ['gu', 'pgf'])
 
 setup (name = 'pgf',
-       version = '1.0',
+       version = '1.1',
        description = 'Python bindings to the Grammatical Framework\'s PGF runtime',
        long_description="""\
 Grammatical Framework (GF) is a programming language for multilingual grammar applications.


### PR DESCRIPTION
Trying in this branch: see
https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#using-secrets-in-a-workflow


> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.
