### PR TITLE
Clarify Apple Silicon installer wording

### DIFF
--- a/download/index-3.12.md
+++ b/download/index-3.12.md
@@ -37,7 +37,7 @@ sudo apt install ./gf-3.12-ubuntu-24.04.deb
 #### macOS
 
 If you are on an Intel Mac (2019 or older), use `gf-3.12-macos-intel.pkg`.<br>
-For newer ARM-based Macs (Apple Silicon M1, M2, M3), use `gf-3.12-macos-arm.pkg`.
+For newer ARM-based Macs (Apple Silicon), use `gf-3.12-macos-arm.pkg`.
 
 After downloading, right click on the file and click on Open.[^1]
 You will see a dialog saying that "macOS cannot verify the developer of "gf-3.12-macos-intel.pkg". Are you sure you want to open it?". 


### PR DESCRIPTION
This updates the macOS download instructions to refer to Apple Silicon generally instead of listing specific M-series generations.

This avoids making the documentation appear limited to M1/M2/M3 Macs, and keeps the wording applicable to newer Apple Silicon Macs as well.